### PR TITLE
Change to wagtail blocks path

### DIFF
--- a/wagtailmath/blocks.py
+++ b/wagtailmath/blocks.py
@@ -1,7 +1,7 @@
 from django.utils.safestring import mark_safe
 from django.template.loader import render_to_string
 from django.forms import Widget, CharField
-from wagtail.core.blocks import FieldBlock
+from wagtail.blocks import FieldBlock
 #from wagtail.core.telepath import register
 #from wagtail.core.widget_adapters import WidgetAdapter
 


### PR DESCRIPTION
Small change for Wagtail 3.0.

RemovedInWagtail50Warning: Importing from wagtail.core.blocks is deprecated. Use wagtail.blocks instead. See https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths

