### PR TITLE
Fix for MathJax Preview Initialization Issue

### DIFF
--- a/src/wagtailmath/static/wagtailmath/js/wagtailmath.js
+++ b/src/wagtailmath/static/wagtailmath/js/wagtailmath.js
@@ -81,7 +81,7 @@ class Preview {
 
 
 function initMathJaxPreview(id) {
-  window.wagtailMathPreviews = window.WagtailMathPreviews || {};
+  window.wagtailMathPreviews = window.wagtailMathPreviews || {};
 
   window.wagtailMathPreviews[id] = new Preview(
     "MathPreview-" + id,


### PR DESCRIPTION
The wagtailMathPreviews object was being reinitialized on every preview setup due to inconsistent casing, causing previously initialized previews to be overwritten and resulting in errors during Update() calls.