### PR TITLE
Adds configurable mathjax cdn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Dropped support for Django < 5.2
 - Upgraded to MathJax 4.1.2, using [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Subresource_Integrity)
   for the CDN script. The template tag has also changed to `mathjax_script`. See upgrade considerations
+- Added `WAGTAILPOLYMATH_MATHJAX_URL` and `WAGTAILPOLYMATH_MATHJAX_SRI` settings to allow loading
+  MathJax from a different CDN, or self-hosted, instead of the pinned jsdelivr default. See
+  [Configuration](README.md#configuration)
 
 ### Upgrade considerations
 
@@ -37,6 +40,11 @@ The `mathjax` template tag has changed to `mathjax_script` and should no longer 
 + {% load wagtail_polymath %}
 + {% mathjax_script %}
 ```
+
+#### `MATHJAX_VERSION`/`MATHJAX_SRI` moved out of `widgets.py`
+These were never documented as public API, but if you imported them
+directly, they now live in `wagtail_polymath.settings` alongside the new
+`get_mathjax_url()`/`get_mathjax_integrity()` helpers.
 
 ## 2.0.0.dev1 (2026-06-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@
 - Dropped support for Django < 5.2
 - Upgraded to MathJax 4.1.2, using [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Subresource_Integrity)
   for the CDN script. The template tag has also changed to `mathjax_script`. See upgrade considerations
-- Added `WAGTAILPOLYMATH_MATHJAX_URL` and `WAGTAILPOLYMATH_MATHJAX_SRI` settings to allow loading
-  MathJax from a different CDN, or self-hosted, instead of the pinned jsdelivr default. See
-  [Configuration](README.md#configuration)
+- Added a `WAGTAIL_POLYMATH` settings dict, with `mathjax_url` and `mathjax_sri` keys, to allow
+  loading MathJax from a different CDN, or self-hosted, instead of the pinned jsdelivr default.
+  See [Configuration](README.md#configuration)
 
 ### Upgrade considerations
 
@@ -43,8 +43,9 @@ The `mathjax` template tag has changed to `mathjax_script` and should no longer 
 
 #### `MATHJAX_VERSION`/`MATHJAX_SRI` moved out of `widgets.py`
 These were never documented as public API, but if you imported them
-directly, they now live in `wagtail_polymath.settings` alongside the new
-`get_mathjax_url()`/`get_mathjax_integrity()` helpers.
+directly, they now live in `wagtail_polymath.settings`, which also exposes
+a `wagtail_polymath_settings` object (`.mathjax_url`/`.mathjax_sri`) for
+reading the effective, resolved settings.
 
 ## 2.0.0.dev1 (2026-06-18)
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,23 @@ WAGTAIL_POLYMATH = {
 `mathjax_sri` has no effect unless `mathjax_url` is also set — the built-in
 default URL always uses its own pinned hash.
 
+To generate the hash for your chosen file, download it and use `openssl`.
+Note that the `integrity` attribute requires a **base64**-encoded digest —
+`sha256sum`/`shasum` produce a hex digest instead, which will not work:
+
+```sh
+openssl dgst -sha256 -binary tex-mml-chtml.js | openssl base64 -A
+```
+
+Prefix the output with `sha256-` to get the full `mathjax_sri` value:
+
+```python
+WAGTAIL_POLYMATH = {
+    "mathjax_url": "https://example.com/path/to/tex-mml-chtml.js",
+    "mathjax_sri": "sha256-dPV35kaoLq1rg+JbYf8p1kTrZamwMY+XIwaWUPwqtpU=",
+}
+```
+
 Both settings apply to the MathJax script loaded in the Wagtail admin (for
 the `MathBlock` live preview) and the one loaded by the `mathjax_script`
 template tag. Note that the bundled preview JS assumes MathJax's combined

--- a/README.md
+++ b/README.md
@@ -83,32 +83,38 @@ MathJax library:
 
 ## Configuration
 
+All `wagtail-polymath` settings are defined in a single `WAGTAIL_POLYMATH`
+dictionary in your settings file.
+
 By default, wagtail-polymath loads MathJax from jsdelivr, pinned to a specific
 version with a matching [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Subresource_Integrity)
 (SRI) hash, so the browser can verify the script hasn't been tampered with.
 
 If you'd rather load MathJax from a different CDN, your own static files, or
-a different version, set `WAGTAILPOLYMATH_MATHJAX_URL` to the full script URL:
+a different version, set `mathjax_url` to the full script URL:
 
 ```python
 # settings.py
-WAGTAILPOLYMATH_MATHJAX_URL = "https://example.com/path/to/tex-mml-chtml.js"
+WAGTAIL_POLYMATH = {
+    "mathjax_url": "https://example.com/path/to/tex-mml-chtml.js",
+}
 ```
 
 Since we can't know the SRI hash for a script we don't control, setting a
 custom URL on its own disables integrity checking for that script (no
 `integrity`/`crossorigin` attributes are rendered). If you want that
-protection back, also set `WAGTAILPOLYMATH_MATHJAX_SRI` to the hash for your
-chosen file:
+protection back, also set `mathjax_sri` to the hash for your chosen file:
 
 ```python
 # settings.py
-WAGTAILPOLYMATH_MATHJAX_URL = "https://example.com/path/to/tex-mml-chtml.js"
-WAGTAILPOLYMATH_MATHJAX_SRI = "sha256-..."
+WAGTAIL_POLYMATH = {
+    "mathjax_url": "https://example.com/path/to/tex-mml-chtml.js",
+    "mathjax_sri": "sha256-...",
+}
 ```
 
-`WAGTAILPOLYMATH_MATHJAX_SRI` has no effect unless `WAGTAILPOLYMATH_MATHJAX_URL`
-is also set — the built-in default URL always uses its own pinned hash.
+`mathjax_sri` has no effect unless `mathjax_url` is also set — the built-in
+default URL always uses its own pinned hash.
 
 Both settings apply to the MathJax script loaded in the Wagtail admin (for
 the `MathBlock` live preview) and the one loaded by the `mathjax_script`

--- a/README.md
+++ b/README.md
@@ -81,6 +81,41 @@ MathJax library:
 {% mathjax_script %}
 ```
 
+## Configuration
+
+By default, wagtail-polymath loads MathJax from jsdelivr, pinned to a specific
+version with a matching [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Subresource_Integrity)
+(SRI) hash, so the browser can verify the script hasn't been tampered with.
+
+If you'd rather load MathJax from a different CDN, your own static files, or
+a different version, set `WAGTAILPOLYMATH_MATHJAX_URL` to the full script URL:
+
+```python
+# settings.py
+WAGTAILPOLYMATH_MATHJAX_URL = "https://example.com/path/to/tex-mml-chtml.js"
+```
+
+Since we can't know the SRI hash for a script we don't control, setting a
+custom URL on its own disables integrity checking for that script (no
+`integrity`/`crossorigin` attributes are rendered). If you want that
+protection back, also set `WAGTAILPOLYMATH_MATHJAX_SRI` to the hash for your
+chosen file:
+
+```python
+# settings.py
+WAGTAILPOLYMATH_MATHJAX_URL = "https://example.com/path/to/tex-mml-chtml.js"
+WAGTAILPOLYMATH_MATHJAX_SRI = "sha256-..."
+```
+
+`WAGTAILPOLYMATH_MATHJAX_SRI` has no effect unless `WAGTAILPOLYMATH_MATHJAX_URL`
+is also set — the built-in default URL always uses its own pinned hash.
+
+Both settings apply to the MathJax script loaded in the Wagtail admin (for
+the `MathBlock` live preview) and the one loaded by the `mathjax_script`
+template tag. Note that the bundled preview JS assumes MathJax's combined
+`tex-mml-chtml` component and its `input/asciimath` loader — if you switch to
+a different version or build of MathJax, you're responsible for keeping it
+compatible with that configuration.
 
 ## Contributing
 

--- a/src/wagtail_polymath/settings.py
+++ b/src/wagtail_polymath/settings.py
@@ -1,0 +1,18 @@
+from django.conf import settings
+
+
+MATHJAX_VERSION = "4.1.2"
+MATHJAX_DEFAULT_URL = (
+    f"https://cdn.jsdelivr.net/npm/mathjax@{MATHJAX_VERSION}/tex-mml-chtml.js"
+)
+MATHJAX_DEFAULT_SRI = "sha256-dPV35kaoLq1rg+JbYf8p1kTrZamwMY+XIwaWUPwqtpU="
+
+
+def get_mathjax_url():
+    return getattr(settings, "WAGTAILPOLYMATH_MATHJAX_URL", None) or MATHJAX_DEFAULT_URL
+
+
+def get_mathjax_integrity():
+    if getattr(settings, "WAGTAILPOLYMATH_MATHJAX_URL", None):
+        return getattr(settings, "WAGTAILPOLYMATH_MATHJAX_SRI", None)
+    return MATHJAX_DEFAULT_SRI

--- a/src/wagtail_polymath/settings.py
+++ b/src/wagtail_polymath/settings.py
@@ -8,11 +8,30 @@ MATHJAX_DEFAULT_URL = (
 MATHJAX_DEFAULT_SRI = "sha256-dPV35kaoLq1rg+JbYf8p1kTrZamwMY+XIwaWUPwqtpU="
 
 
-def get_mathjax_url():
-    return getattr(settings, "WAGTAILPOLYMATH_MATHJAX_URL", None) or MATHJAX_DEFAULT_URL
+class WagtailPolymathSettings:
+    """
+    Shadows Django's settings, exposing the WAGTAIL_POLYMATH dict as attributes.
+    For example:
+        from wagtail_polymath.settings import wagtail_polymath_settings
+        print(wagtail_polymath_settings.mathjax_url)
+    """
+
+    @property
+    def _user_settings(self):
+        return getattr(settings, "WAGTAIL_POLYMATH", {})
+
+    @property
+    def mathjax_url(self):
+        return self._user_settings.get("mathjax_url") or MATHJAX_DEFAULT_URL
+
+    @property
+    def mathjax_sri(self):
+        if self._user_settings.get("mathjax_url"):
+            # We can't know the hash for a script we don't control, so a
+            # custom URL without a matching mathjax_sri setting intentionally
+            # omits integrity checking rather than erroring.
+            return self._user_settings.get("mathjax_sri")
+        return MATHJAX_DEFAULT_SRI
 
 
-def get_mathjax_integrity():
-    if getattr(settings, "WAGTAILPOLYMATH_MATHJAX_URL", None):
-        return getattr(settings, "WAGTAILPOLYMATH_MATHJAX_SRI", None)
-    return MATHJAX_DEFAULT_SRI
+wagtail_polymath_settings = WagtailPolymathSettings()

--- a/src/wagtail_polymath/settings.py
+++ b/src/wagtail_polymath/settings.py
@@ -18,8 +18,8 @@ class WagtailPolymathSettings:
 
     @property
     def _user_settings(self):
-        return getattr(settings, "WAGTAIL_POLYMATH", {})
-
+        user_settings = getattr(settings, "WAGTAIL_POLYMATH", None)
+        return user_settings if isinstance(user_settings, dict) else {}
     @property
     def mathjax_url(self):
         return self._user_settings.get("mathjax_url") or MATHJAX_DEFAULT_URL

--- a/src/wagtail_polymath/templatetags/wagtail_polymath.py
+++ b/src/wagtail_polymath/templatetags/wagtail_polymath.py
@@ -3,7 +3,7 @@ from django.forms.utils import flatatt
 from django.utils.html import format_html
 from wagtail.admin.staticfiles import versioned_static
 
-from wagtail_polymath.settings import get_mathjax_integrity, get_mathjax_url
+from wagtail_polymath.settings import wagtail_polymath_settings
 
 
 register = template.Library()
@@ -12,7 +12,7 @@ register = template.Library()
 @register.simple_tag
 def mathjax_script():
     attributes = {"defer": True}
-    integrity = get_mathjax_integrity()
+    integrity = wagtail_polymath_settings.mathjax_sri
     if integrity:
         attributes["crossorigin"] = "anonymous"
         attributes["integrity"] = integrity
@@ -20,6 +20,6 @@ def mathjax_script():
     return format_html(
         '<script src="{init_path}"></script><script src="{path}"{attributes}></script>',
         init_path=versioned_static("wagtail_polymath/js/mathjax_init.js"),
-        path=get_mathjax_url(),
+        path=wagtail_polymath_settings.mathjax_url,
         attributes=flatatt(attributes),
     )

--- a/src/wagtail_polymath/templatetags/wagtail_polymath.py
+++ b/src/wagtail_polymath/templatetags/wagtail_polymath.py
@@ -3,7 +3,7 @@ from django.forms.utils import flatatt
 from django.utils.html import format_html
 from wagtail.admin.staticfiles import versioned_static
 
-from wagtail_polymath.widgets import MATHJAX_SRI, MATHJAX_VERSION
+from wagtail_polymath.settings import get_mathjax_integrity, get_mathjax_url
 
 
 register = template.Library()
@@ -11,10 +11,15 @@ register = template.Library()
 
 @register.simple_tag
 def mathjax_script():
-    attributes = {"crossorigin": "anonymous", "integrity": MATHJAX_SRI, "defer": True}
+    attributes = {"defer": True}
+    integrity = get_mathjax_integrity()
+    if integrity:
+        attributes["crossorigin"] = "anonymous"
+        attributes["integrity"] = integrity
+
     return format_html(
         '<script src="{init_path}"></script><script src="{path}"{attributes}></script>',
         init_path=versioned_static("wagtail_polymath/js/mathjax_init.js"),
-        path=f"https://cdn.jsdelivr.net/npm/mathjax@{MATHJAX_VERSION}/tex-mml-chtml.js",
+        path=get_mathjax_url(),
         attributes=flatatt(attributes),
     )

--- a/src/wagtail_polymath/widgets.py
+++ b/src/wagtail_polymath/widgets.py
@@ -2,7 +2,7 @@ from django import forms
 from django.forms import Script
 from wagtail.admin.staticfiles import versioned_static
 
-from .settings import get_mathjax_integrity, get_mathjax_url
+from .settings import wagtail_polymath_settings
 
 
 class MathJaxWidget(forms.Textarea):
@@ -17,14 +17,14 @@ class MathJaxWidget(forms.Textarea):
     @property
     def media(self):
         attrs = {"defer": True}
-        integrity = get_mathjax_integrity()
+        integrity = wagtail_polymath_settings.mathjax_sri
         if integrity:
             attrs["crossorigin"] = "anonymous"
             attrs["integrity"] = integrity
 
         return forms.Media(
             js=(
-                Script(get_mathjax_url(), **attrs),
+                Script(wagtail_polymath_settings.mathjax_url, **attrs),
                 versioned_static("wagtail_polymath/js/wagtail_polymath.js"),
                 versioned_static(
                     "wagtail_polymath/js/wagtail_polymath-mathjax-controller.js"

--- a/src/wagtail_polymath/widgets.py
+++ b/src/wagtail_polymath/widgets.py
@@ -2,9 +2,7 @@ from django import forms
 from django.forms import Script
 from wagtail.admin.staticfiles import versioned_static
 
-
-MATHJAX_VERSION = "4.1.2"
-MATHJAX_SRI = "sha256-dPV35kaoLq1rg+JbYf8p1kTrZamwMY+XIwaWUPwqtpU="
+from .settings import get_mathjax_integrity, get_mathjax_url
 
 
 class MathJaxWidget(forms.Textarea):
@@ -18,16 +16,15 @@ class MathJaxWidget(forms.Textarea):
 
     @property
     def media(self):
+        attrs = {"defer": True}
+        integrity = get_mathjax_integrity()
+        if integrity:
+            attrs["crossorigin"] = "anonymous"
+            attrs["integrity"] = integrity
+
         return forms.Media(
             js=(
-                Script(
-                    f"https://cdn.jsdelivr.net/npm/mathjax@{MATHJAX_VERSION}/tex-mml-chtml.js",
-                    **{
-                        "crossorigin": "anonymous",
-                        "integrity": MATHJAX_SRI,
-                        "defer": True,
-                    },
-                ),
+                Script(get_mathjax_url(), **attrs),
                 versioned_static("wagtail_polymath/js/wagtail_polymath.js"),
                 versioned_static(
                     "wagtail_polymath/js/wagtail_polymath-mathjax-controller.js"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,8 +1,7 @@
 from wagtail_polymath.settings import (
     MATHJAX_DEFAULT_SRI,
     MATHJAX_DEFAULT_URL,
-    get_mathjax_integrity,
-    get_mathjax_url,
+    wagtail_polymath_settings,
 )
 from wagtail_polymath.templatetags.wagtail_polymath import mathjax_script
 from wagtail_polymath.widgets import MathJaxWidget
@@ -17,13 +16,13 @@ def widget_media_html():
 
 
 class TestDefaultMathJaxSettings:
-    """No WAGTAILPOLYMATH_MATHJAX_* settings configured."""
+    """No WAGTAIL_POLYMATH setting configured."""
 
-    def test_get_mathjax_url_returns_default(self):
-        assert get_mathjax_url() == MATHJAX_DEFAULT_URL
+    def test_mathjax_url_returns_default(self):
+        assert wagtail_polymath_settings.mathjax_url == MATHJAX_DEFAULT_URL
 
-    def test_get_mathjax_integrity_returns_default(self):
-        assert get_mathjax_integrity() == MATHJAX_DEFAULT_SRI
+    def test_mathjax_sri_returns_default(self):
+        assert wagtail_polymath_settings.mathjax_sri == MATHJAX_DEFAULT_SRI
 
     def test_widget_media_uses_default_url_and_integrity(self):
         html = widget_media_html()
@@ -39,18 +38,18 @@ class TestDefaultMathJaxSettings:
 
 
 class TestCustomUrlOnly:
-    """WAGTAILPOLYMATH_MATHJAX_URL set, no matching SRI hash supplied."""
+    """WAGTAIL_POLYMATH["mathjax_url"] set, no matching SRI hash supplied."""
 
-    def test_get_mathjax_url_returns_custom_url(self, settings):
-        settings.WAGTAILPOLYMATH_MATHJAX_URL = CUSTOM_URL
-        assert get_mathjax_url() == CUSTOM_URL
+    def test_mathjax_url_returns_custom_url(self, settings):
+        settings.WAGTAIL_POLYMATH = {"mathjax_url": CUSTOM_URL}
+        assert wagtail_polymath_settings.mathjax_url == CUSTOM_URL
 
-    def test_get_mathjax_integrity_is_none(self, settings):
-        settings.WAGTAILPOLYMATH_MATHJAX_URL = CUSTOM_URL
-        assert get_mathjax_integrity() is None
+    def test_mathjax_sri_is_none(self, settings):
+        settings.WAGTAIL_POLYMATH = {"mathjax_url": CUSTOM_URL}
+        assert wagtail_polymath_settings.mathjax_sri is None
 
     def test_widget_media_omits_integrity(self, settings):
-        settings.WAGTAILPOLYMATH_MATHJAX_URL = CUSTOM_URL
+        settings.WAGTAIL_POLYMATH = {"mathjax_url": CUSTOM_URL}
         html = widget_media_html()
         assert CUSTOM_URL in html
         assert MATHJAX_DEFAULT_URL not in html
@@ -58,7 +57,7 @@ class TestCustomUrlOnly:
         assert "crossorigin" not in html
 
     def test_template_tag_omits_integrity(self, settings):
-        settings.WAGTAILPOLYMATH_MATHJAX_URL = CUSTOM_URL
+        settings.WAGTAIL_POLYMATH = {"mathjax_url": CUSTOM_URL}
         html = mathjax_script()
         assert CUSTOM_URL in html
         assert "integrity" not in html
@@ -66,31 +65,37 @@ class TestCustomUrlOnly:
 
 
 class TestCustomUrlAndSri:
-    """Both WAGTAILPOLYMATH_MATHJAX_URL and WAGTAILPOLYMATH_MATHJAX_SRI set."""
+    """Both mathjax_url and mathjax_sri set in WAGTAIL_POLYMATH."""
 
-    def test_get_mathjax_integrity_returns_custom_sri(self, settings):
-        settings.WAGTAILPOLYMATH_MATHJAX_URL = CUSTOM_URL
-        settings.WAGTAILPOLYMATH_MATHJAX_SRI = CUSTOM_SRI
-        assert get_mathjax_integrity() == CUSTOM_SRI
+    def test_mathjax_sri_returns_custom_sri(self, settings):
+        settings.WAGTAIL_POLYMATH = {
+            "mathjax_url": CUSTOM_URL,
+            "mathjax_sri": CUSTOM_SRI,
+        }
+        assert wagtail_polymath_settings.mathjax_sri == CUSTOM_SRI
 
     def test_widget_media_uses_custom_url_and_integrity(self, settings):
-        settings.WAGTAILPOLYMATH_MATHJAX_URL = CUSTOM_URL
-        settings.WAGTAILPOLYMATH_MATHJAX_SRI = CUSTOM_SRI
+        settings.WAGTAIL_POLYMATH = {
+            "mathjax_url": CUSTOM_URL,
+            "mathjax_sri": CUSTOM_SRI,
+        }
         html = widget_media_html()
         assert CUSTOM_URL in html
         assert f'integrity="{CUSTOM_SRI}"' in html
         assert 'crossorigin="anonymous"' in html
 
     def test_template_tag_uses_custom_url_and_integrity(self, settings):
-        settings.WAGTAILPOLYMATH_MATHJAX_URL = CUSTOM_URL
-        settings.WAGTAILPOLYMATH_MATHJAX_SRI = CUSTOM_SRI
+        settings.WAGTAIL_POLYMATH = {
+            "mathjax_url": CUSTOM_URL,
+            "mathjax_sri": CUSTOM_SRI,
+        }
         html = mathjax_script()
         assert CUSTOM_URL in html
         assert f'integrity="{CUSTOM_SRI}"' in html
         assert 'crossorigin="anonymous"' in html
 
     def test_sri_ignored_without_matching_url(self, settings):
-        """The SRI setting alone (no custom URL) must not affect the default."""
-        settings.WAGTAILPOLYMATH_MATHJAX_SRI = CUSTOM_SRI
-        assert get_mathjax_url() == MATHJAX_DEFAULT_URL
-        assert get_mathjax_integrity() == MATHJAX_DEFAULT_SRI
+        """The mathjax_sri key alone (no mathjax_url) must not affect the default."""
+        settings.WAGTAIL_POLYMATH = {"mathjax_sri": CUSTOM_SRI}
+        assert wagtail_polymath_settings.mathjax_url == MATHJAX_DEFAULT_URL
+        assert wagtail_polymath_settings.mathjax_sri == MATHJAX_DEFAULT_SRI

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,96 @@
+from wagtail_polymath.settings import (
+    MATHJAX_DEFAULT_SRI,
+    MATHJAX_DEFAULT_URL,
+    get_mathjax_integrity,
+    get_mathjax_url,
+)
+from wagtail_polymath.templatetags.wagtail_polymath import mathjax_script
+from wagtail_polymath.widgets import MathJaxWidget
+
+
+CUSTOM_URL = "https://example.com/mathjax/tex-mml-chtml.js"
+CUSTOM_SRI = "sha256-Ynv3Q3nAtRTr6UDX+X6vbn9d1t8ZO5oV2Y4gvL9y0ck="
+
+
+def widget_media_html():
+    return str(MathJaxWidget().media)
+
+
+class TestDefaultMathJaxSettings:
+    """No WAGTAILPOLYMATH_MATHJAX_* settings configured."""
+
+    def test_get_mathjax_url_returns_default(self):
+        assert get_mathjax_url() == MATHJAX_DEFAULT_URL
+
+    def test_get_mathjax_integrity_returns_default(self):
+        assert get_mathjax_integrity() == MATHJAX_DEFAULT_SRI
+
+    def test_widget_media_uses_default_url_and_integrity(self):
+        html = widget_media_html()
+        assert MATHJAX_DEFAULT_URL in html
+        assert f'integrity="{MATHJAX_DEFAULT_SRI}"' in html
+        assert 'crossorigin="anonymous"' in html
+
+    def test_template_tag_uses_default_url_and_integrity(self):
+        html = mathjax_script()
+        assert MATHJAX_DEFAULT_URL in html
+        assert f'integrity="{MATHJAX_DEFAULT_SRI}"' in html
+        assert 'crossorigin="anonymous"' in html
+
+
+class TestCustomUrlOnly:
+    """WAGTAILPOLYMATH_MATHJAX_URL set, no matching SRI hash supplied."""
+
+    def test_get_mathjax_url_returns_custom_url(self, settings):
+        settings.WAGTAILPOLYMATH_MATHJAX_URL = CUSTOM_URL
+        assert get_mathjax_url() == CUSTOM_URL
+
+    def test_get_mathjax_integrity_is_none(self, settings):
+        settings.WAGTAILPOLYMATH_MATHJAX_URL = CUSTOM_URL
+        assert get_mathjax_integrity() is None
+
+    def test_widget_media_omits_integrity(self, settings):
+        settings.WAGTAILPOLYMATH_MATHJAX_URL = CUSTOM_URL
+        html = widget_media_html()
+        assert CUSTOM_URL in html
+        assert MATHJAX_DEFAULT_URL not in html
+        assert "integrity" not in html
+        assert "crossorigin" not in html
+
+    def test_template_tag_omits_integrity(self, settings):
+        settings.WAGTAILPOLYMATH_MATHJAX_URL = CUSTOM_URL
+        html = mathjax_script()
+        assert CUSTOM_URL in html
+        assert "integrity" not in html
+        assert "crossorigin" not in html
+
+
+class TestCustomUrlAndSri:
+    """Both WAGTAILPOLYMATH_MATHJAX_URL and WAGTAILPOLYMATH_MATHJAX_SRI set."""
+
+    def test_get_mathjax_integrity_returns_custom_sri(self, settings):
+        settings.WAGTAILPOLYMATH_MATHJAX_URL = CUSTOM_URL
+        settings.WAGTAILPOLYMATH_MATHJAX_SRI = CUSTOM_SRI
+        assert get_mathjax_integrity() == CUSTOM_SRI
+
+    def test_widget_media_uses_custom_url_and_integrity(self, settings):
+        settings.WAGTAILPOLYMATH_MATHJAX_URL = CUSTOM_URL
+        settings.WAGTAILPOLYMATH_MATHJAX_SRI = CUSTOM_SRI
+        html = widget_media_html()
+        assert CUSTOM_URL in html
+        assert f'integrity="{CUSTOM_SRI}"' in html
+        assert 'crossorigin="anonymous"' in html
+
+    def test_template_tag_uses_custom_url_and_integrity(self, settings):
+        settings.WAGTAILPOLYMATH_MATHJAX_URL = CUSTOM_URL
+        settings.WAGTAILPOLYMATH_MATHJAX_SRI = CUSTOM_SRI
+        html = mathjax_script()
+        assert CUSTOM_URL in html
+        assert f'integrity="{CUSTOM_SRI}"' in html
+        assert 'crossorigin="anonymous"' in html
+
+    def test_sri_ignored_without_matching_url(self, settings):
+        """The SRI setting alone (no custom URL) must not affect the default."""
+        settings.WAGTAILPOLYMATH_MATHJAX_SRI = CUSTOM_SRI
+        assert get_mathjax_url() == MATHJAX_DEFAULT_URL
+        assert get_mathjax_integrity() == MATHJAX_DEFAULT_SRI


### PR DESCRIPTION
Some users need to point at a different CDN, an internal mirror, or a self-hosted copy of MathJax...

This adds support for configuring the MathJax CDN URL (and its SRI hash) via settings, instead of always loading MathJax from the pinned jsdelivr URL. 

Added the `WAGTAIL_POLYMATH` setting with:
- `mathjax_url` full URL to the MathJax script. Defaults to the existing pinned jsdelivr URL if unset.
- `mathjax_sri` optional [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Subresource_Integrity) hash to pair with a custom URL. Only has an effect alongside `WAGTAILPOLYMATH_MATHJAX_URL`; the default URL always uses its own pinned hash.
- If a custom URL is set without a matching SRI hash, the `integrity`/`crossorigin` attributes are omitted.
